### PR TITLE
use dots to represent attribute and skill values

### DIFF
--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -2,8 +2,8 @@
 
 /* Fonts */
 @font-face {
-  font-family: 'cormorantLight';
-  src: url('../assets/fonts/Cormorant-Light-webfont.woff') format('woff');
+  font-family: "cormorantLight";
+  src: url("../assets/fonts/Cormorant-Light-webfont.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }
@@ -142,12 +142,14 @@
 /* New Styles */
 .vtm5e .window-content {
   background: #faf5ed;
-  font-family: 'cormorantLight', sans-serif;
+  font-family: "cormorantLight", sans-serif;
   font-weight: 600;
 }
 
 .vtm5e .profile-img,
-.vtm5e .item-image img { background: #790813; }
+.vtm5e .item-image img {
+  background: #790813;
+}
 
 .vtm5e input {
   font-family: initial;
@@ -158,7 +160,7 @@
 .vtm5e button.rollable {
   background: #790813;
   color: white;
-  font-family: 'cormorantlight', sans-serif;
+  font-family: "cormorantlight", sans-serif;
   font-weight: bold;
   border: none;
 }
@@ -364,6 +366,25 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.2s ease-out;
+}
+
+/* Resource boxes CSS */
+
+.vtm5e .resource-value input {
+  display: none;
+}
+
+.vtm5e .resource-value .resource-value-step {
+  height: 14px;
+  width: 14px;
+  border: 1px solid black;
+  display: inline-block;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.vtm5e .resource-value .resource-value-step.active {
+  background-color: #790813;
 }
 
 /* ChatMessage CSS */

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -193,6 +193,8 @@ export class VampireActorSheet extends ActorSheet {
   activateListeners (html) {
     super.activateListeners(html)
 
+    this._setupResources(html)
+
     // Everything below here is only needed if the sheet is editable
     if (!this.options.editable) return
 
@@ -230,6 +232,8 @@ export class VampireActorSheet extends ActorSheet {
 
     // Rollable Vampire powers.
     html.find('.power-rollable').click(this._onVampireRoll.bind(this))
+
+    html.find('.resource-value > .resource-value-step').click(this._onResourceValueChange.bind(this))
 
     // Drag events for macros.
     // if (this.actor.owner) {
@@ -563,5 +567,36 @@ export class VampireActorSheet extends ActorSheet {
     const dice2 = item.data.data.dice2 === 'discipline' ? disciplineValue : this.actor.data.data.abilities[item.data.data.dice2].value
     const dicePool = dice1 + dice2
     this._vampireRoll(dicePool, this.actor, `${item.data.name}`)
+  }
+
+  _onResourceValueChange (event) {
+    event.preventDefault()
+    const elem = event.currentTarget
+    const value = Number(elem.getAttribute('data-value'))
+    const parent = $(elem.parentNode)
+    const steps = parent.find('.resource-value-step')
+    if (value < 0 || value > steps.length) {
+      return
+    }
+
+    steps.removeClass('active')
+    steps.each(function (i) {
+      if (i <= value) {
+        $(this).addClass('active')
+      }
+    })
+
+    parent.find('input').val(value+1)
+  }
+
+  _setupResources (html) {
+    html.find('.resource-value').each(function () {
+      const value = Number($(this).find('input').val())
+      $(this).find('.resource-value-step').each(function (i) {
+        if (i + 1 <= value) {
+          $(this).addClass('active')
+        }
+      })
+    })
   }
 }

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -128,8 +128,12 @@
                     <label for="data.abilities.{{key}}.value" class="resource-label vrollable"
                         data-roll="{{ability.value}}" data-label="{{localize ability.name}}">{{localize
                         ability.name}}</label>
-                    <input type="number" name="data.abilities.{{key}}.value" min="0" value="{{ability.value}}"
-                        data-dtype="Number" />
+                    <div class="resource-value">
+                        {{#numLoop 6}}
+                        <span class="resource-value-step" data-value="{{this}}"></span>
+                        {{/numLoop}}
+                        <input type="number" name="data.abilities.{{key}}.value" min="0" value="{{ability.value}}" data-dtype="Number" />
+                    </div>
                 </div>
                 {{/each}}
             </div>
@@ -140,8 +144,13 @@
                 <div class="skill flexrow flex-center">
                     <label for="data.skills.{{key}}.value" class="resource-label vrollable" data-roll="{{skill.value}}"
                         data-label="{{localize skill.name}}">{{localize skill.name}}</label>
-                    <input type="number" name="data.skills.{{key}}.value" min="0" value="{{skill.value}}"
+                    <div class="resource-value">
+                        {{#numLoop 5}}
+                        <span class="resource-value-step" data-value="{{this}}"></span>
+                        {{/numLoop}}
+                        <input type="number" name="data.skills.{{key}}.value" min="0" value="{{skill.value}}"
                         data-dtype="Number" />
+                    </div>
                 </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
This commit adds support for representing attribute and skill
values as a set of dots, just like the paper character sheet.

Final result:
![Screenshot from 2021-02-07 14-53-26](https://user-images.githubusercontent.com/1312023/107148660-bc2a7300-6954-11eb-8e55-6f35bf55c997.png)
