### PR TITLE
Some fixes/additions to willpower rerolls

### DIFF
--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -553,7 +553,7 @@
 }
 
 .roll-img {
-  max-width: 80%;
+  max-width: 30px;
   margin: 1px;
   background: rgba(255, 255, 255, 0.5);
   border-radius: 3px;
@@ -562,10 +562,6 @@
 .roll-img.hunger-dice {
   background: rgba(255, 230, 230, 0.5);
   border-color: #790813;
-}
-
-.chat-message .roll-img {
-  max-width: 10%;
 }
 
 .vtm5e .locked .resource-value-empty:not(.hunger-value) {
@@ -578,15 +574,15 @@
 }
 
 .willpowerReroll .die {
-  margin-left: 3px;
+  flex: 0;
 }
 
 .willpowerReroll .selected::after {
   position: absolute;
   content: 'X';
-  font-size: 24px;
+  font-size: 30px;
   color: red;
-  margin-left: -20px;
+  margin-left: -25px;
   margin-top: -2px;
 }
 

--- a/module/main.js
+++ b/module/main.js
@@ -271,7 +271,7 @@ async function willpowerReroll (roll) {
             <label><b>Select dice to reroll (Max 3)</b></label>
             <hr>
             <span class="dice-tooltip">
-              <div class="dice-rolls willpowerReroll flexrow">
+              <div class="dice-rolls flexrow willpowerReroll">
                 ${diceRolls.reverse().join('')}
               </div>
             </span>

--- a/module/main.js
+++ b/module/main.js
@@ -232,7 +232,6 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
 /* -------------------------------------------- */
 
 // Create context menu option on selection
-// TODO: Add condition that it only shows up on willpower-able rolls
 Hooks.on('getChatLogEntryContext', function (html, options) {
   options.push({
     name: game.i18n.localize('VTM5E.WillpowerReroll'),

--- a/module/main.js
+++ b/module/main.js
@@ -241,7 +241,11 @@ Hooks.on('getChatLogEntryContext', function (html, options) {
       // Only show this context menu if the person is GM or author of the message
       const message = game.messages.get(li.attr('data-message-id'))
 
-      return game.user.isGM || message.isAuthor
+      // Only show this context menu if there are re-rollable dice in the message
+      const rerollableDice = li.find('.normal-dice').length
+
+      // All must be true to show the reroll dialogue
+      return (game.user.isGM || message.isAuthor) && (rerollableDice > 0)
     },
     callback: li => willpowerReroll(li)
   })


### PR DESCRIPTION
Various tweaks to the reroll dialogue:
- The reroll dialogue and the chat should have uniform dice sizes now
- The X on dice selection is properly sized/positioned now.
- In-chat reroll dialogue option now only shows up on rerollable messages