### PR TITLE
Disciplines update

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -39,6 +39,10 @@
   background: #fff;
 }
 
+.vtm5e.dark-theme .discipline-description {
+  color: #ccc;
+}
+
 /* Resource boxes CSS */
 .vtm5e.dark-theme .resource-value .resource-value-step {
   border: 1px solid #cdcdcd;

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -210,6 +210,22 @@
   border-radius: 5px;
 }
 
+.vtm5e .window-content .header-fields select {
+  max-width: 150px;
+  float: right;
+}
+
+.vtm5e .window-content .header-fields .level {
+  flex-grow: 0;
+  margin-left: 10px;
+  align-self: center;
+}
+
+.vtm5e .window-content .header-fields .level input {
+  max-width: 35px;
+  float: left;
+}
+
 .vtm5e .window-content .abilities,
 .vtm5e.sheet.actor .window-content .skills {
   border: none;
@@ -369,6 +385,10 @@
   color: #790813;
 }
 
+.vtm5e .items-list .item-header .header-level {
+  text-align: center;
+}
+
 .vtm5e .items-list .item {
   min-height: 30px;
   line-height: 24px;
@@ -396,7 +416,6 @@
 }
 
 .vtm5e .items-list .item-controls {
-  flex: 0 0 86px;
   text-align: right;
 }
 
@@ -412,6 +431,11 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.2s ease-out;
+}
+
+.vtm5e .discipline-description {
+  width: 100%;
+  resize: none;
 }
 
 /* Resource boxes CSS */
@@ -523,6 +547,7 @@
 
 .vtm5e .tab.disciplines .resource-value {
   margin-top: 2px;
+  text-align: center;
 }
 
 /* ChatMessage CSS */

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -221,6 +221,12 @@
   align-self: center;
 }
 
+.vtm5e .sheet-header h1.charname input {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
 .vtm5e .window-content .header-fields .level input {
   max-width: 35px;
   float: left;
@@ -320,12 +326,6 @@
   text-align: center;
   flex: 0;
   width: 100%;
-}
-
-.vtm5e .sheet-header h1.charname input {
-  width: 100%;
-  height: 100%;
-  margin: 0;
 }
 
 .vtm5e .sheet-tabs {

--- a/lang/en.json
+++ b/lang/en.json
@@ -94,7 +94,7 @@
     
     "VTM5E.Level": "Level",
     "VTM5E.Add": "Add",
-    "VTM5E.AddPower": "Add",
+    "VTM5E.AddPower": "Add Power",
     "VTM5E.SelectDiscipline": "Select Discipline",
     "VTM5E.AddDiscipline": "Add Discipline",
     "VTM5E.Animalism": "Animalism",

--- a/module/actor/blood-potency.js
+++ b/module/actor/blood-potency.js
@@ -1,7 +1,15 @@
 /* global game */
 
+// NOTE: The blood potency table uses the updated rules from the v5 Companion
+
+// surge: Amount of dice added on a blood surge
+// mend: Amount mended on expenditure of vitae
+// power: Bonus to discipline powers
+// rouse: Max level of powers that can be rouse-rerolled
+// bane: Bane severity number
 export function getBloodPotencyValues (level) {
   const BLOOD_POTENCY_VALUES = [
+    // Potency 0
     {
       surge: 1,
       mend: 1,
@@ -9,6 +17,7 @@ export function getBloodPotencyValues (level) {
       rouse: 0,
       bane: 0
     },
+    // Potency 1
     {
       surge: 2,
       mend: 1,
@@ -16,6 +25,7 @@ export function getBloodPotencyValues (level) {
       rouse: 1,
       bane: 2
     },
+    // Potency 2
     {
       surge: 2,
       mend: 2,
@@ -23,6 +33,7 @@ export function getBloodPotencyValues (level) {
       rouse: 1,
       bane: 2
     },
+    // Potency 3
     {
       surge: 3,
       mend: 2,
@@ -30,6 +41,7 @@ export function getBloodPotencyValues (level) {
       rouse: 2,
       bane: 3
     },
+    // Potency 4
     {
       surge: 3,
       mend: 3,
@@ -37,6 +49,7 @@ export function getBloodPotencyValues (level) {
       rouse: 2,
       bane: 3
     },
+    // Potency 5
     {
       surge: 4,
       mend: 3,
@@ -44,6 +57,7 @@ export function getBloodPotencyValues (level) {
       rouse: 3,
       bane: 4
     },
+    // Potency 6
     {
       surge: 4,
       mend: 3,
@@ -51,6 +65,7 @@ export function getBloodPotencyValues (level) {
       rouse: 3,
       bane: 4
     },
+    // Potency 7
     {
       surge: 5,
       mend: 3,
@@ -58,6 +73,7 @@ export function getBloodPotencyValues (level) {
       rouse: 4,
       bane: 5
     },
+    // Potency 8
     {
       surge: 5,
       mend: 4,
@@ -65,6 +81,7 @@ export function getBloodPotencyValues (level) {
       rouse: 4,
       bane: 5
     },
+    // Potency 9
     {
       surge: 6,
       mend: 4,
@@ -72,6 +89,7 @@ export function getBloodPotencyValues (level) {
       rouse: 5,
       bane: 6
     },
+    // Potency 10
     {
       surge: 6,
       mend: 5,

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -1,4 +1,4 @@
-/* global Dialog, game, mergeObject */
+/* global Dialog, game, mergeObject, renderTemplate, ChatMessage */
 
 import { MortalActorSheet } from './mortal-actor-sheet.js'
 
@@ -222,30 +222,30 @@ export class GhoulActorSheet extends MortalActorSheet {
     // and the power's level
     // Potency 0 never rolls additional rouse dice for disciplines
     if (potency === 0) {
-      return(1)
+      return (1)
     } else
     // Potency of 9 and 10 always roll additional rouse dice for disciplines
     if (potency > 8) {
-      return(2)
+      return (2)
     } else
     // Potency 7 and 8 roll additional rouse dice on discipline powers below 5
     if (potency > 6 && level < 5) {
-      return(2)
+      return (2)
     } else
     // Potency 5 and 6 roll additional rouse dice on discipline powers below 4
     if (potency > 4 && level < 4) {
-      return(2)
+      return (2)
     } else
     // Potency 3 and 4 roll additional rouse dice on discipline powers below 3
     if (potency > 2 && level < 3) {
-      return(2)
+      return (2)
     } else
     // Potency 1 and 2 roll additional rouse dice on discipline powers below 2
     if (potency > 0 && level < 2) {
-      return(2)
+      return (2)
     }
 
     // If none of the above are true, just roll 1 dice for the rouse check
-    return(1)
+    return (1)
   }
 }

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -117,6 +117,34 @@ export class GhoulActorSheet extends MortalActorSheet {
       this.actor.update({ [`data.disciplines.${data.discipline}.visible`]: false })
     })
 
+    // Post Discipline description to the chat
+    html.find('.discipline-chat').click(ev => {
+      const data = $(ev.currentTarget)[0].dataset
+      const discipline = this.actor.data.data.disciplines[data.discipline]
+
+      renderTemplate('systems/vtm5e/templates/actor/parts/chat-message.html', {
+        name: game.i18n.localize(discipline.name),
+        img: 'icons/svg/dice-target.svg',
+        description: discipline.description
+      }).then(html => {
+        ChatMessage.create({
+          content: html
+        })
+      })
+    })
+
+    // Roll a rouse check for an item
+    html.find('.item-rouse').click(ev => {
+      const li = $(ev.currentTarget).parents('.item')
+      const item = this.actor.getEmbeddedDocument('Item', li.data('itemId'))
+      const level = item.data.data.level
+      const potency = this.actor.data.data.blood.potency
+
+      const dicepool = this.potencyToRouse(potency, level)
+
+      rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, false, true, false)
+    })
+
     // Rollable Vampire/Ghouls powers
     html.find('.power-rollable').click(this._onVampireRoll.bind(this))
   }
@@ -187,5 +215,37 @@ export class GhoulActorSheet extends MortalActorSheet {
 
     const dicePool = dice1 + dice2
     rollDice(dicePool, this.actor, `${item.data.name}`, 0, this.hunger)
+  }
+
+  potencyToRouse (potency, level) {
+    // Define the number of dice to roll based on the user's blood potency
+    // and the power's level
+    // Potency 0 never rolls additional rouse dice for disciplines
+    if (potency === 0) {
+      return(1)
+    } else
+    // Potency of 9 and 10 always roll additional rouse dice for disciplines
+    if (potency > 8) {
+      return(2)
+    } else
+    // Potency 7 and 8 roll additional rouse dice on discipline powers below 5
+    if (potency > 6 && level < 5) {
+      return(2)
+    } else
+    // Potency 5 and 6 roll additional rouse dice on discipline powers below 4
+    if (potency > 4 && level < 4) {
+      return(2)
+    } else
+    // Potency 3 and 4 roll additional rouse dice on discipline powers below 3
+    if (potency > 2 && level < 3) {
+      return(2)
+    } else
+    // Potency 1 and 2 roll additional rouse dice on discipline powers below 2
+    if (potency > 0 && level < 2) {
+      return(2)
+    }
+
+    // If none of the above are true, just roll 1 dice for the rouse check
+    return(1)
   }
 }

--- a/module/actor/roll-dice.js
+++ b/module/actor/roll-dice.js
@@ -135,7 +135,6 @@ export async function rollDice (numDice, actor, label = '', difficulty = 0, useH
   if (increaseHunger && game.settings.get('vtm5e', 'automatedRouse')) {
     // Check if the roll failed (matters for discipline
     // power-based rouse checks that roll 2 dice instead of 1)
-    console.log(difficulty + " - " + totalSuccess)
     if ((difficulty === 0 && totalSuccess === 0) || (totalSuccess < difficulty)) {
       const actorHunger = actor.data.data.hunger.value
 
@@ -149,7 +148,7 @@ export async function rollDice (numDice, actor, label = '', difficulty = 0, useH
       } else {
         // Define the new number of hunger points
         const newHunger = actor.data.data.hunger.value + 1
-  
+
         // Push it to the actor's sheet
         actor.update({ 'data.hunger.value': newHunger })
       }

--- a/module/actor/roll-dice.js
+++ b/module/actor/roll-dice.js
@@ -132,22 +132,27 @@ export async function rollDice (numDice, actor, label = '', difficulty = 0, useH
   })
 
   // Automatically add hunger to the actor on a failure (for rouse checks)
-  if (increaseHunger && totalSuccess === 0 && game.settings.get('vtm5e', 'automatedRouse')) {
-    const actorHunger = actor.data.data.hunger.value
+  if (increaseHunger && game.settings.get('vtm5e', 'automatedRouse')) {
+    // Check if the roll failed (matters for discipline
+    // power-based rouse checks that roll 2 dice instead of 1)
+    console.log(difficulty + " - " + totalSuccess)
+    if ((difficulty === 0 && totalSuccess === 0) || (totalSuccess < difficulty)) {
+      const actorHunger = actor.data.data.hunger.value
 
-    // If hunger is greater than 4 (5, or somehow higher)
-    // then display that in the chat and don't increase hunger
-    if (actorHunger > 4) {
-      roll.toMessage({
-        speaker: ChatMessage.getSpeaker({ actor: actor }),
-        content: game.i18n.localize('VTM5E.HungerFull')
-      })
-    } else {
-      // Define the new number of hunger points
-      const newHunger = actor.data.data.hunger.value + 1
-
-      // Push it to the actor's sheet
-      actor.update({ 'data.hunger.value': newHunger })
+      // If hunger is greater than 4 (5, or somehow higher)
+      // then display that in the chat and don't increase hunger
+      if (actorHunger > 4) {
+        roll.toMessage({
+          speaker: ChatMessage.getSpeaker({ actor: actor }),
+          content: game.i18n.localize('VTM5E.HungerFull')
+        })
+      } else {
+        // Define the new number of hunger points
+        const newHunger = actor.data.data.hunger.value + 1
+  
+        // Push it to the actor's sheet
+        actor.update({ 'data.hunger.value': newHunger })
+      }
     }
   }
 

--- a/system.json
+++ b/system.json
@@ -5,7 +5,7 @@
   "version": "1.8.0",
   "minimumCoreVersion": "0.8.0",
   "compatibleCoreVersion": "0.9.0",
-  "templateVersion": 3,
+  "templateVersion": 4,
   "author": "Ray Ji",
   "esmodules": ["module/main.js"],
   "styles": ["css/vtm5e.css"],

--- a/template.json
+++ b/template.json
@@ -186,84 +186,98 @@
         "disciplines": {
           "animalism": {
             "name": "VTM5E.Animalism",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "auspex": {
             "name": "VTM5E.Auspex",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "celerity": {
             "name": "VTM5E.Celerity",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "dominate": {
             "name": "VTM5E.Dominate",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "fortitude": {
             "name": "VTM5E.Fortitude",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "obfuscate": {
             "name": "VTM5E.Obfuscate",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "potence": {
             "name": "VTM5E.Potence",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "presence": {
             "name": "VTM5E.Presence",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "protean": {
             "name": "VTM5E.Protean",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "sorcery": {
             "name": "VTM5E.BloodSorcery",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "oblivion": {
             "name": "VTM5E.Oblivion",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "alchemy": {
             "name": "VTM5E.ThinBloodAlchemy",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "rituals": {
             "name": "VTM5E.Rituals",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
           },
           "ceremonies": {
             "name": "VTM5E.Ceremonies",
+            "description": "",
             "value": 0,
             "powers": [],
             "visible": false
@@ -344,12 +358,14 @@
       "templates": ["base"],
       "discipline": "rituals",
       "duration": "",
+      "level": 1,
       "dice1": "discipline",
       "dice2": "discipline",
       "cost": "",
       "rollable": false,
       "skill": false,
-      "amalgam": false
+      "amalgam": false,
+      "rouse": false
     },
     "specialty": {
       "templates": ["base"],

--- a/templates/actor/parts/disciplines.html
+++ b/templates/actor/parts/disciplines.html
@@ -3,12 +3,12 @@
         <!-- Header of the disciplines lists -->
         <li class="item flexrow item-header">
             <div class="item-name">{{localize "VTM5E.Name"}}</div>
-            <div class="item-name">{{localize "VTM5E.Level"}}</div>
+            <div class="item-name header-level">{{localize "VTM5E.Level"}}</div>
             <!-- Item controls for adding new discipline lists -->
             <div class="item-controls">
-                <a class="item-control discipline-create" title="{{localize 'VTM5E.Add'}}">
+                <a class="item-control discipline-create" title="{{localize 'VTM5E.AddDiscipline'}}">
                     <i class="fas fa-plus"></i>
-                    {{localize "VTM5E.Add"}}
+                    {{localize "VTM5E.AddDiscipline"}}
                 </a>
             </div>
         </li>
@@ -16,11 +16,11 @@
         {{#each data.data.disciplines as |discipline key|}}
             {{#if discipline.visible}}
                 <li class="flexrow item-header">
+                    <div class="item-name collapsible">
+                        {{localize discipline.name}}
+                    </div>
                     <!-- All non-ritual/ceremony powers need dots displayed in the middle -->
                     {{#if (and (ne key "rituals") (ne key "ceremonies"))}}
-                        <div class="item-name vrollable" data-roll="{{discipline.value}}" data-label="{{key}}">
-                            {{localize discipline.name}}
-                        </div>
                         <div class="resource-value" data-value="{{discipline.value}}" data-name="data.disciplines.{{key}}.value">
                             <!-- Empty box (for setting back to 0), and then iterate through the rest of the discipline dots -->
                             <span class="resource-value-empty"></span>
@@ -28,23 +28,31 @@
                                 <span class="resource-value-step" data-index="{{this}}"></span>
                             {{/numLoop}}
                         </div>
-                    <!-- Rituals and Ceremonies sections don't need dots -->
-                    {{else}}
-                        <div class="item-name" data-roll="{{discipline.value}}" data-label="{{key}}">
-                            {{localize discipline.name}}
-                        </div>
                     {{/if}}
                     <!-- Item controls for Discipline sections -->
                     <div class="item-controls">
+                        <!-- Add new discipline power -->
                         <a class="item-control item-create" title="{{localize 'VTM5E.AddPower'}}" data-type="power" data-discipline="{{key}}">
                             <i class="fas fa-plus"></i>
-                            {{localize "VTM5E.AddPower"}}
                         </a>
+                        <!-- Icon to roll the discipline with an attribute -->
+                        <a class="vrollable discipline-dice" title="{{localize 'VTM5E.Roll'}}" data-roll="{{discipline.value}}" data-label="{{key}}">
+                            <i class="fas fa-dice-d20"></i>
+                        </a>
+                        <!-- Icon to show the discipline description to the chat-->
+                        <a class="item-control discipline-chat" title="{{localize 'VTM5E.ShowToChat'}}" data-type="power" data-discipline="{{key}}">
+                            <i class="fas fa-comment-alt"></i>
+                        </a>
+                        <!-- Icon to delete the discipline (as long as it doesn't have any powers) -->
                         <a class="item-control discipline-delete" title="{{localize 'VTM5E.Delete'}}" data-discipline="{{key}}">
                             <i class="fas fa-trash"></i>
                         </a>
                     </div>
                 </li>
+                <!-- Discipline description -->
+                <div class="collapsible-content">
+                    <textarea class="discipline-description" name="data.disciplines.{{key}}.description">{{discipline.description}}</textarea>
+                </div>
                 <!-- Iterate through each of the discipline powers -->
                 {{#each (lookup ../actor.disciplines_list key) as |item id|}}
                     <li class="item flexcol" data-item-id="{{item._id}}">
@@ -63,12 +71,21 @@
                             <h4 class="item-name collapsible">{{item.name}}</h4>
                             <!-- Item controls for discipline powers -->
                             <div class="item-controls">
-                                <a class="item-control item-chat" title="{{localize 'VTM5E.ShowToChat'}}">
-                                    <i class="fas fa-comment-alt"></i>
-                                </a>
+                                <!-- Icon to roll the power's rouse check, if applicable -->
+                                {{#if item.data.rouse}}
+                                    <a class="item-control item-rouse" title="{{localize 'VTM5E.RollRouse'}}" data-roll="{{discipline.value}}">
+                                        <i class="fas fa-dice-d20"></i>
+                                    </a>
+                                {{/if}}
+                                <!-- Icon to edit the power-->
                                 <a class="item-control item-edit" title="{{localize 'VTM5E.Edit'}}">
                                     <i class="fas fa-edit"></i>
                                 </a>
+                                <!-- Icon to display the power in chat -->
+                                <a class="item-control item-chat" title="{{localize 'VTM5E.ShowToChat'}}">
+                                    <i class="fas fa-comment-alt"></i>
+                                </a>
+                                <!-- Icon to delete the power -->
                                 <a class="item-control item-delete" title="{{localize 'VTM5E.Delete'}}">
                                     <i class="fas fa-trash"></i>
                                 </a>
@@ -76,7 +93,7 @@
                         </div>
                         <!-- Power description, expandable by a collapse -->
                         <div class="collapsible-content">
-                            {{{item.data.description}}}
+                            {{item.data.description}}
                         </div>
                     </li>
                 {{/each}}

--- a/templates/actor/parts/disciplines.html
+++ b/templates/actor/parts/disciplines.html
@@ -4,6 +4,7 @@
         <li class="item flexrow item-header">
             <div class="item-name">{{localize "VTM5E.Name"}}</div>
             <div class="item-name">{{localize "VTM5E.Level"}}</div>
+            <!-- Item controls for adding new discipline lists -->
             <div class="item-controls">
                 <a class="item-control discipline-create" title="{{localize 'VTM5E.Add'}}">
                     <i class="fas fa-plus"></i>
@@ -15,6 +16,7 @@
         {{#each data.data.disciplines as |discipline key|}}
             {{#if discipline.visible}}
                 <li class="flexrow item-header">
+                    <!-- All non-ritual/ceremony powers need dots displayed in the middle -->
                     {{#if (and (ne key "rituals") (ne key "ceremonies"))}}
                         <div class="item-name vrollable" data-roll="{{discipline.value}}" data-label="{{key}}">
                             {{localize discipline.name}}
@@ -47,6 +49,7 @@
                 {{#each (lookup ../actor.disciplines_list key) as |item id|}}
                     <li class="item flexcol" data-item-id="{{item._id}}">
                         <div class="flexrow">
+                            <!-- Whether the button is clickable or not to post the power in chat -->
                             {{#if item.data.rollable}}
                                 <div class="item-image power-rollable" data-id="{{item._id}}" data-use-hunger="1">
                                     <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" alt="{{item.name}}"/>
@@ -56,6 +59,7 @@
                                     <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" alt="{{item.name}}"/>
                                 </div>
                             {{/if}}
+                            <!-- Discipline power name -->
                             <h4 class="item-name collapsible">{{item.name}}</h4>
                             <!-- Item controls for discipline powers -->
                             <div class="item-controls">

--- a/templates/actor/parts/disciplines.html
+++ b/templates/actor/parts/disciplines.html
@@ -1,5 +1,6 @@
 <div class="tab disciplines" data-group="primary" data-tab="disciplines">
     <ol class="items-list">
+        <!-- Header of the disciplines lists -->
         <li class="item flexrow item-header">
             <div class="item-name">{{localize "VTM5E.Name"}}</div>
             <div class="item-name">{{localize "VTM5E.Level"}}</div>
@@ -10,55 +11,72 @@
                 </a>
             </div>
         </li>
+        <!-- Iterate through each of the discipline lists -->
         {{#each data.data.disciplines as |discipline key|}}
-        {{#if discipline.visible}}
-        <li class="flexrow item-header">
-            {{#if (and (ne key "rituals") (ne key "ceremonies"))}}
-            <div class="item-name vrollable" data-roll="{{discipline.value}}" data-label="{{key}}">{{localize
-                discipline.name}}</div>
-            <div class="resource-value" data-value="{{discipline.value}}" data-name="data.disciplines.{{key}}.value">
-                <span class="resource-value-empty"></span>
-                {{#numLoop 5}}
-                <span class="resource-value-step" data-index="{{this}}"></span>
-                {{/numLoop}}
-            </div>
-            {{else}}
-            <div class="item-name" data-roll="{{discipline.value}}" data-label="{{key}}">{{localize discipline.name}}
-            </div>
+            {{#if discipline.visible}}
+                <li class="flexrow item-header">
+                    {{#if (and (ne key "rituals") (ne key "ceremonies"))}}
+                        <div class="item-name vrollable" data-roll="{{discipline.value}}" data-label="{{key}}">
+                            {{localize discipline.name}}
+                        </div>
+                        <div class="resource-value" data-value="{{discipline.value}}" data-name="data.disciplines.{{key}}.value">
+                            <!-- Empty box (for setting back to 0), and then iterate through the rest of the discipline dots -->
+                            <span class="resource-value-empty"></span>
+                            {{#numLoop 5}}
+                                <span class="resource-value-step" data-index="{{this}}"></span>
+                            {{/numLoop}}
+                        </div>
+                    <!-- Rituals and Ceremonies sections don't need dots -->
+                    {{else}}
+                        <div class="item-name" data-roll="{{discipline.value}}" data-label="{{key}}">
+                            {{localize discipline.name}}
+                        </div>
+                    {{/if}}
+                    <!-- Item controls for Discipline sections -->
+                    <div class="item-controls">
+                        <a class="item-control item-create" title="{{localize 'VTM5E.AddPower'}}" data-type="power" data-discipline="{{key}}">
+                            <i class="fas fa-plus"></i>
+                            {{localize "VTM5E.AddPower"}}
+                        </a>
+                        <a class="item-control discipline-delete" title="{{localize 'VTM5E.Delete'}}" data-discipline="{{key}}">
+                            <i class="fas fa-trash"></i>
+                        </a>
+                    </div>
+                </li>
+                <!-- Iterate through each of the discipline powers -->
+                {{#each (lookup ../actor.disciplines_list key) as |item id|}}
+                    <li class="item flexcol" data-item-id="{{item._id}}">
+                        <div class="flexrow">
+                            {{#if item.data.rollable}}
+                                <div class="item-image power-rollable" data-id="{{item._id}}" data-use-hunger="1">
+                                    <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" alt="{{item.name}}"/>
+                                </div>
+                            {{else}}
+                                <div class="item-image" data-id="{{item._id}}">
+                                    <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" alt="{{item.name}}"/>
+                                </div>
+                            {{/if}}
+                            <h4 class="item-name collapsible">{{item.name}}</h4>
+                            <!-- Item controls for discipline powers -->
+                            <div class="item-controls">
+                                <a class="item-control item-chat" title="{{localize 'VTM5E.ShowToChat'}}">
+                                    <i class="fas fa-comment-alt"></i>
+                                </a>
+                                <a class="item-control item-edit" title="{{localize 'VTM5E.Edit'}}">
+                                    <i class="fas fa-edit"></i>
+                                </a>
+                                <a class="item-control item-delete" title="{{localize 'VTM5E.Delete'}}">
+                                    <i class="fas fa-trash"></i>
+                                </a>
+                            </div>
+                        </div>
+                        <!-- Power description, expandable by a collapse -->
+                        <div class="collapsible-content">
+                            {{{item.data.description}}}
+                        </div>
+                    </li>
+                {{/each}}
             {{/if}}
-            <div class="item-controls">
-                <a class="item-control item-create" title="{{localize 'VTM5E.AddPower'}}" data-type="power"
-                    data-discipline="{{key}}"><i class="fas fa-plus"></i> {{localize "VTM5E.AddPower"}}</a>
-                <a class="item-control discipline-delete" title="{{localize 'VTM5E.Delete'}}"
-                    data-discipline="{{key}}"><i class="fas fa-trash"></i></a>
-            </div>
-        </li>
-        {{#each (lookup ../actor.disciplines_list key) as |item id|}}
-        <li class="item flexcol" data-item-id="{{item._id}}">
-            <div class="flexrow">
-                {{#if item.data.rollable}}
-                <div class="item-image power-rollable" data-id="{{item._id}}" data-use-hunger="1"><img src="{{item.img}}"
-                        title="{{item.name}}" width="24" height="24" alt="{{item.name}}" /></div>
-                {{else}}
-                <div class="item-image" data-id="{{item._id}}"><img src="{{item.img}}" title="{{item.name}}"
-                        width="24" height="24" alt="{{item.name}}" /></div>
-                {{/if}}
-                <h4 class="item-name collapsible">{{item.name}}</h4>
-                <div class="item-controls">
-                    <a class="item-control item-chat" title="{{localize 'VTM5E.ShowToChat'}}"><i
-                        class="fas fa-comment-alt"></i></a>
-                    <a class="item-control item-edit" title="{{localize 'VTM5E.Edit'}}"><i
-                            class="fas fa-edit"></i></a>
-                    <a class="item-control item-delete" title="{{localize 'VTM5E.Delete'}}"><i
-                            class="fas fa-trash"></i></a>
-                </div>
-            </div>
-            <div class="collapsible-content">
-                {{{item.data.description}}}
-            </div>
-        </li>
-        {{/each}}
-        {{/if}}
         {{/each}}
     </ol>
 </div>

--- a/templates/item/item-power-sheet.html
+++ b/templates/item/item-power-sheet.html
@@ -1,9 +1,24 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" alt="Item Image" />
-        <div class="header-fields">
+        <div class="header-fields flexcol">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}"
                     placeholder="{{localize 'VTM5E.Name'}}" /></h1>
+            <div class="flexrow">
+                <!-- Input the level of the discipline -->
+                <div class="flexrow level">
+                    <label>{{localize "VTM5E.Level"}}</label>
+                    <input name="data.level" value="{{item.data.data.level}}" type="number" min="0" max="5"/>
+                </div>
+                <!-- Select the discipline this power belongs to -->
+                <div class="discipline">
+                    <select name="data.discipline" data-type="String">
+                        {{#select data.data.discipline}}
+                        {{> "systems/vtm5e/templates/item/parts/disciplines.html"}}
+                        {{/select}}
+                    </select>
+                </div>
+            </div>
         </div>
     </header>
 
@@ -35,16 +50,7 @@
         <div class="tab attributes" data-group="primary" data-tab="attributes">
             {{!-- As you add new fields, add them in here! --}}
             <div class="resource grid grid-4col flex-center">
-                <label class="resource-label">{{localize "VTM5E.Discipline"}}: </label>
-                <select name="data.discipline" data-type="String">
-                    {{#select data.data.discipline}}
-                    {{> "systems/vtm5e/templates/item/parts/disciplines.html"}}
-                    {{/select}}
-                </select>
-
-                <div></div>
-                <div></div>
-
+                <!-- Define the system that the power uses -->
                 <label class="resource-label">{{localize "VTM5E.System"}}: </label>
                 <select name="data.dice1" data-type="String">
                     {{#select data.data.dice1}}
@@ -54,42 +60,49 @@
                 </select>
                 <label class="resource-label">+</label>
                 {{#if data.data.skill}}
-                <select name="data.dice2" data-type="String">
-                    {{#select data.data.dice2}}
-                    {{> "systems/vtm5e/templates/item/parts/skills.html"}}
-                    {{/select}}
-                </select>
+                    <select name="data.dice2" data-type="String">
+                        {{#select data.data.dice2}}
+                        {{> "systems/vtm5e/templates/item/parts/skills.html"}}
+                        {{/select}}
+                    </select>
                 {{else if data.data.amalgam}}
-                <select name="data.dice2" data-type="String">
-                    {{#select data.data.dice2}}
-                    {{> "systems/vtm5e/templates/item/parts/disciplines.html"}}
-                    {{/select}}
-                </select>
+                    <select name="data.dice2" data-type="String">
+                        {{#select data.data.dice2}}
+                        {{> "systems/vtm5e/templates/item/parts/disciplines.html"}}
+                        {{/select}}
+                    </select>
                 {{else}}
-                <select name="data.dice2" data-type="String">
-                    {{#select data.data.dice2}}
-                     {{> "systems/vtm5e/templates/item/parts/attributes.html"}}
-                    <option value="discipline">{{localize (getDisciplineName item.data.data.discipline)}}</option>
-                    {{/select}}
-                </select>
+                    <select name="data.dice2" data-type="String">
+                        {{#select data.data.dice2}}
+                        {{> "systems/vtm5e/templates/item/parts/attributes.html"}}
+                        <option value="discipline">{{localize (getDisciplineName item.data.data.discipline)}}</option>
+                        {{/select}}
+                    </select>
                 {{/if}}
 
+                <!-- Rollable or not -->
                 <label class="resource-label">{{localize "VTM5E.Rollable"}}: </label>
                 <input type="checkbox" id="data.rollable" name="data.rollable" {{checked data.data.rollable}}>
 
+                <!-- Whether the "system" option uses skills or not -->
                 <label class="resource-label">{{localize "VTM5E.UseSkill"}}: </label>
                 {{#if data.data.amalgam}}
-                <input type="checkbox" id="data.skill" name="data.skill" disabled {{checked data.data.skill}}>
+                    <input type="checkbox" id="data.skill" name="data.skill" disabled {{checked data.data.skill}}>
                 {{else}}
-                <input type="checkbox" id="data.skill" name="data.skill" {{checked data.data.skill}}>
+                    <input type="checkbox" id="data.skill" name="data.skill" {{checked data.data.skill}}>
                 {{/if}}
 
+                <!-- Adds other discipline options to the "system" option -->
                 <label class="resource-label">{{localize "VTM5E.Amalgam"}}: </label>
                 {{#if data.data.skill}}
-                <input type="checkbox" id="data.amalgam" name="data.amalgam" disabled {{checked data.data.amalgam}}>
+                    <input type="checkbox" id="data.amalgam" name="data.amalgam" disabled {{checked data.data.amalgam}}>
                 {{else}}
-                <input type="checkbox" id="data.amalgam" name="data.amalgam" {{checked data.data.amalgam}}>
+                  <input type="checkbox" id="data.amalgam" name="data.amalgam" {{checked data.data.amalgam}}>
                 {{/if}}
+
+                <!-- If the item has a rouse check to roll or not -->
+                <label class="resource-label">{{localize "VTM5E.Rouse"}}: </label>
+                <input type="checkbox" id="data.rouse" name="data.rouse" {{checked data.data.rouse}}>
 
             </div>
         </div>


### PR DESCRIPTION
* Fixed the disciplines tab to be more well-centred (screenshot below)
* Added a bunch of comments/fixed formatting within the HTML of the Disciplines page to help with developer readability
* Adjusted the look of the Discipline Power item sheet (screenshot below)
* Added the ability to do a rouse check for a specific discipline that takes into account the vampire's blood potency and the level of the power to determine whether to roll 2 rouse dice or 1, which resolves issue #61 
* Added the ability to put a description onto discipline categories, which technically resolves the closed issue #118 

![Image showing the modified disciplines tab](https://user-images.githubusercontent.com/15100566/148678068-512df635-6a85-4c36-8229-ae1259cc0acb.png)
![Updated Discipline Power itemsheet](https://user-images.githubusercontent.com/15100566/148678080-9408a1e9-fcdc-4a34-a931-2c3c9604ae23.png)
![Example of the new discipline description area.](https://user-images.githubusercontent.com/15100566/148678095-fb7dab4e-1167-4baf-838a-5a81f0e55cec.png)
![Example of what powers with rouse checks enabled look like.](https://user-images.githubusercontent.com/15100566/148678164-c55c18ac-49cd-41b1-9c6f-b78476be20ed.png)

