### PR TITLE
Update vtm5e.css

### DIFF
--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -6,7 +6,7 @@
 @font-face {
   font-family: cormorantLight;
   src: url("../assets/fonts/Cormorant-Light-webfont.woff") format("woff");
-  font-weight: normal;
+  h1, h2, h3, h4, h5, h6, p { font-weight : normal;  }
   font-style: normal;
 }
 


### PR DESCRIPTION
The fonts displays badly on firefox. Making the proposed change let the font be as clear on Firefox as it is on Chrome, and has no impact on display for Chrome.