### PR TITLE
disable gitleaks

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -25,3 +25,4 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSCPD: false 
+          VALIDATE_GITLEAKS: false


### PR DESCRIPTION
Stop gap for replacing super-linter. This simply disables gitleaks checks. This is mainly a front-end project that doesn't deal with secrets so disabling gitleaks does not impact us.