### PR TITLE
Use hunger dice for Rouse checks in the dice tray and for disciplines

### DIFF
--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -141,7 +141,7 @@ export class GhoulActorSheet extends MortalActorSheet {
 
       const dicepool = this.potencyToRouse(potency, level)
 
-      rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, false, true, false)
+      rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, true, true, false)
     })
 
     // Rollable Vampire/Ghouls powers

--- a/module/dice/dicebox.js
+++ b/module/dice/dicebox.js
@@ -148,7 +148,7 @@ function describePool (poolNumber, data) {
 export function prepareRouseShortcut ($content, data) {
   $content.find('.dice-tray-button[data=rollRouse]').on('click', event => {
     event.preventDefault()
-    rollDice(1, data.selectedCharacter, game.i18n.localize('VTM5E.RousingBlood'), 1, false, true, false)
+    rollDice(1, data.selectedCharacter, game.i18n.localize('VTM5E.RousingBlood'), 1, true, true, false)
   })
 }
 


### PR DESCRIPTION
Use hunger dice for Rouse checks in the dice tray and for disciplines. 
rouse checks from the button still use normale dice.