### PR TITLE
Fix rouse checks and rollable vampire powers, plus sort powers by level

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -60,6 +60,8 @@
 
 .vtm5e.dark-theme .rollable:hover,
 .vtm5e.dark-theme .rollable:focus,
+.vtm5e.dark-theme .rouse-check:hover,
+.vtm5e.dark-theme .rouse-check:focus,
 .vtm5e.dark-theme .rollable-with-mod:hover,
 .vtm5e.dark-theme .rollable-with-mod:focus,
 .vtm5e.dark-theme .vrollable:hover,

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -493,15 +493,6 @@ optgroup {
     border-radius: 0;
 }
 
-.vtm5e.item .window-content input {
-    float: left;
-    background-color: #ffd578;
-}
-
-.vtm5e.item.sheet .window-content input[type="number"] {
-    max-width: 35px;
-}
-
 .vtm5e .window-content .abilities,
 .vtm5e.sheet.actor .window-content .skills {
     border: none;
@@ -538,6 +529,15 @@ optgroup {
     text-transform: uppercase;
     font-size: 20px;
     font-weight: 700;
+}
+
+.vtm5e.item .window-content input {
+    float: left;
+    background-color: #ffd578;
+}
+
+.vtm5e.item.sheet .window-content input[type="number"] {
+    max-width: 35px;
 }
 
 .vtm5e .actor-header h1.charname {

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -363,6 +363,15 @@ optgroup {
     text-align: center;
 }
 
+.vtm5e.item .window-content input {
+    float: left;
+    background-color: #ffd578;
+}
+
+.vtm5e.item.sheet .window-content input[type="number"] {
+    max-width: 35px;
+}
+
 .vtm5e .actor-header h1.charname input {
     width: 100%;
     height: 100%;
@@ -529,15 +538,6 @@ optgroup {
     text-transform: uppercase;
     font-size: 20px;
     font-weight: 700;
-}
-
-.vtm5e.item .window-content input {
-    float: left;
-    background-color: #ffd578;
-}
-
-.vtm5e.item.sheet .window-content input[type="number"] {
-    max-width: 35px;
 }
 
 .vtm5e .actor-header h1.charname {

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -493,10 +493,11 @@ optgroup {
     border-radius: 0;
 }
 
-.vtm5e.item.sheet .window-content input {
+.vtm5e.item .window-content input {
     float: left;
-    background-color: #ffca55;
+    background-color: #ffd578;
 }
+
 .vtm5e.item.sheet .window-content input[type="number"] {
     max-width: 35px;
 }

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -493,10 +493,12 @@ optgroup {
     border-radius: 0;
 }
 
-.vtm5e .window-content .header-fields .level input, .vtm5e .itemsheet-textbox {
-    max-width: 35px;
+.vtm5e.item.sheet .window-content input {
     float: left;
     background-color: #ffca55;
+}
+.vtm5e.item.sheet .window-content input[type="number"] {
+    max-width: 35px;
 }
 
 .vtm5e .window-content .abilities,

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -110,6 +110,8 @@ button:focus {
 .rollable:focus,
 .rollable-with-mod:hover,
 .rollable-with-mod:focus,
+.rouse-check:hover,
+.rouse-check:focus,
 .vrollable:hover,
 .vrollable:focus,
 .power-rollable:hover,
@@ -263,7 +265,8 @@ optgroup {
 }
 
 .vtm5e button.rollable,
-.vtm5e button.rollable-with-mod {
+.vtm5e button.rollable-with-mod,
+.vtm5e button.rouse-check {
     background: #790813;
     color: #fff;
     font-family: cormorantLight, serif;
@@ -274,7 +277,8 @@ optgroup {
 }
 
 .vtm5e button.rollable:hover,
-.vtm5e button.rollable-with-mod:hover {
+.vtm5e button.rollable-with-mod:hover,
+.vtm5e button.rouse-check {
     outline: none;
     box-shadow: inset 0 0 5px #000;
     background: var(--color-shadow-highlight);

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -143,7 +143,7 @@ export class GhoulActorSheet extends MortalActorSheet {
       if (this.actor.type === 'vampire') {
         const potency = this.actor.type === 'vampire' ? this.actor.system.blood.potency : 0
         const dicepool = this.potencyToRouse(potency, level)
-  
+
         rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, 0, true, false)
       } else if (this.actor.type === 'ghoul' && level > 1) {
         // Ghouls take aggravated damage for using powers above level 1 instead of rolling rouse checks

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -153,13 +153,19 @@ export class GhoulActorSheet extends MortalActorSheet {
       const li = $(ev.currentTarget).parents('.item')
       const item = this.actor.getEmbeddedDocument('Item', li.data('itemId'))
       const level = item.system.level
+      const cost = item.system.cost > 0 ? item.system.cost : 1
+      let dicepool
 
       // Vampires roll rouse checks
       if (this.actor.type === 'vampire') {
         const potency = this.actor.type === 'vampire' ? this.actor.system.blood.potency : 0
-        const dicepool = this.potencyToRouse(potency, level)
+        const rouseRerolls = this.potencyToRouse(potency, level)
 
-        rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, dicepool, true, false)
+        // Double the number of dice to roll if rouseRerolls is true
+        // otherwise, just use the cost
+        dicepool = rouseRerolls ? cost * 2 : cost
+
+        rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), cost, dicepool, true, false)
       } else if (this.actor.type === 'ghoul' && level > 1) {
         // Ghouls take aggravated damage for using powers above level 1 instead of rolling rouse checks
         const actorHealth = this.actor.system.health
@@ -251,34 +257,34 @@ export class GhoulActorSheet extends MortalActorSheet {
   }
 
   potencyToRouse (potency, level) {
-    // Define the number of dice to roll based on the user's blood potency
+    // Define whether to reroll dice based on the user's blood potency
     // and the power's level
     // Potency 0 never rolls additional rouse dice for disciplines
     if (potency === 0) {
-      return (1)
+      return false
     } else
     // Potency of 9 and 10 always roll additional rouse dice for disciplines
     if (potency > 8) {
-      return (2)
+      return true
     } else
     // Potency 7 and 8 roll additional rouse dice on discipline powers below 5
     if (potency > 6 && level < 5) {
-      return (2)
+      return true
     } else
     // Potency 5 and 6 roll additional rouse dice on discipline powers below 4
     if (potency > 4 && level < 4) {
-      return (2)
+      return true
     } else
     // Potency 3 and 4 roll additional rouse dice on discipline powers below 3
     if (potency > 2 && level < 3) {
-      return (2)
+      return true
     } else
     // Potency 1 and 2 roll additional rouse dice on discipline powers below 2
     if (potency > 0 && level < 2) {
-      return (2)
+      return true
     }
 
     // If none of the above are true, just roll 1 dice for the rouse check
-    return (1)
+    return false
   }
 }

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -97,14 +97,14 @@ export class GhoulActorSheet extends MortalActorSheet {
 
     // Sort the discipline containers by the level of the power instead of by creation date
     for (const discipline in disciplines) {
-      disciplines[discipline] = disciplines[discipline].sort(function(power1, power2) {
-          // If the levels are the same, sort alphabetically instead
-          if (power1.system.level === power2.system.level) {
-            return power1.name.localeCompare(power2.name)
-          }
+      disciplines[discipline] = disciplines[discipline].sort(function (power1, power2) {
+        // If the levels are the same, sort alphabetically instead
+        if (power1.system.level === power2.system.level) {
+          return power1.name.localeCompare(power2.name)
+        }
 
-          // Sort by level
-          return power1.system.level - power2.system.level
+        // Sort by level
+        return power1.system.level - power2.system.level
       })
     }
 

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -95,6 +95,19 @@ export class GhoulActorSheet extends MortalActorSheet {
       }
     }
 
+    // Sort the discipline containers by the level of the power instead of by creation date
+    for (const discipline in disciplines) {
+      disciplines[discipline] = disciplines[discipline].sort(function(power1, power2) {
+          // If the levels are the same, sort alphabetically instead
+          if (power1.system.level === power2.system.level) {
+            return power1.name.localeCompare(power2.name)
+          }
+
+          // Sort by level
+          return power1.system.level - power2.system.level
+      })
+    }
+
     // Assign and return
     actorData.disciplines_list = disciplines
   }

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -133,6 +133,21 @@ export class GhoulActorSheet extends MortalActorSheet {
       })
     })
 
+    // Roll a general rouse check
+    html.find('.rouse-check').click(event => {
+      event.preventDefault()
+      const element = event.currentTarget
+      const dataset = element.dataset
+      const numDice = dataset.roll
+      const difficulty = dataset.difficulty
+  
+      // See if we need to reduce hunger on this roll
+      const increaseHunger = dataset.increaseHunger
+      
+      // Roll the rouse check
+      rollDice(numDice, this.actor, `${dataset.label}`, difficulty, numDice, increaseHunger)
+    })
+
     // Roll a rouse check for an item
     html.find('.item-rouse').click(ev => {
       const li = $(ev.currentTarget).parents('.item')
@@ -144,7 +159,7 @@ export class GhoulActorSheet extends MortalActorSheet {
         const potency = this.actor.type === 'vampire' ? this.actor.system.blood.potency : 0
         const dicepool = this.potencyToRouse(potency, level)
 
-        rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, 0, true, false)
+        rollDice(dicepool, this.actor, game.i18n.localize('VTM5E.RousingBlood'), 1, dicepool, true, false)
       } else if (this.actor.type === 'ghoul' && level > 1) {
         // Ghouls take aggravated damage for using powers above level 1 instead of rolling rouse checks
         const actorHealth = this.actor.system.health

--- a/module/actor/ghoul-actor-sheet.js
+++ b/module/actor/ghoul-actor-sheet.js
@@ -140,10 +140,10 @@ export class GhoulActorSheet extends MortalActorSheet {
       const dataset = element.dataset
       const numDice = dataset.roll
       const difficulty = dataset.difficulty
-  
+
       // See if we need to reduce hunger on this roll
       const increaseHunger = dataset.increaseHunger
-      
+
       // Roll the rouse check
       rollDice(numDice, this.actor, `${dataset.label}`, difficulty, numDice, increaseHunger)
     })

--- a/module/actor/hunter-actor-sheet.js
+++ b/module/actor/hunter-actor-sheet.js
@@ -108,6 +108,21 @@ export class HunterActorSheet extends CellActorSheet {
       }
     }
 
+    // Sort the edge containers by the level of the power instead of by creation date
+    for (const edgeType in edges) {
+      for (const edge in edges[edgeType]) {
+        edges[edgeType] = edges[edgeType].sort(function(power1, power2) {
+          // If the levels are the same, sort alphabetically instead
+          if (power1.system.level === power2.system.level) {
+            return power1.name.localeCompare(power2.name)
+          }
+
+          // Sort by level
+          return power1.system.level - power2.system.level
+        })
+      }
+    }
+
     // Assign and return
     actorData.edges_list = edges
   }

--- a/module/actor/hunter-actor-sheet.js
+++ b/module/actor/hunter-actor-sheet.js
@@ -110,17 +110,15 @@ export class HunterActorSheet extends CellActorSheet {
 
     // Sort the edge containers by the level of the power instead of by creation date
     for (const edgeType in edges) {
-      for (const edge in edges[edgeType]) {
-        edges[edgeType] = edges[edgeType].sort(function(power1, power2) {
-          // If the levels are the same, sort alphabetically instead
-          if (power1.system.level === power2.system.level) {
-            return power1.name.localeCompare(power2.name)
-          }
+      edges[edgeType] = edges[edgeType].sort(function (power1, power2) {
+        // If the levels are the same, sort alphabetically instead
+        if (power1.system.level === power2.system.level) {
+          return power1.name.localeCompare(power2.name)
+        }
 
-          // Sort by level
-          return power1.system.level - power2.system.level
-        })
-      }
+        // Sort by level
+        return power1.system.level - power2.system.level
+      })
     }
 
     // Assign and return

--- a/module/actor/werewolf-actor-sheet.js
+++ b/module/actor/werewolf-actor-sheet.js
@@ -83,21 +83,19 @@ export class WerewolfActorSheet extends WoDActor {
 
     // Sort the gift containers by the level of the power instead of by creation date
     for (const giftType in giftsList) {
-      for (const gift in giftsList[giftType].powers) {
-        giftsList[giftType].powers = giftsList[giftType].powers.sort(function(power1, power2) {
-          // If the levels are the same, sort alphabetically instead
-          if (power1.system.level === power2.system.level) {
-            return power1.name.localeCompare(power2.name)
-          }
+      giftsList[giftType].powers = giftsList[giftType].powers.sort(function (power1, power2) {
+        // If the levels are the same, sort alphabetically instead
+        if (power1.system.level === power2.system.level) {
+          return power1.name.localeCompare(power2.name)
+        }
 
-          // Sort by level
-          return power1.system.level - power2.system.level
-        })
-      }
+        // Sort by level
+        return power1.system.level - power2.system.level
+      })
     }
 
     // Sort the rite containers by the level of the power instead of by creation date
-    ritesList = ritesList.sort(function(power1, power2) {
+    ritesList = ritesList.sort(function (power1, power2) {
       // If the levels are the same, sort alphabetically instead
       if (power1.system.level === power2.system.level) {
         return power1.name.localeCompare(power2.name)

--- a/module/actor/werewolf-actor-sheet.js
+++ b/module/actor/werewolf-actor-sheet.js
@@ -64,7 +64,7 @@ export class WerewolfActorSheet extends WoDActor {
     actorData.system.gamesystem = 'werewolf'
 
     const giftsList = structuredClone(actorData.system.gifts)
-    const ritesList = structuredClone(actorData.system.rites)
+    let ritesList = structuredClone(actorData.system.rites)
 
     // Iterate through items, allocating to containers
     for (const i of sheetData.items) {
@@ -80,6 +80,32 @@ export class WerewolfActorSheet extends WoDActor {
         }
       }
     }
+
+    // Sort the gift containers by the level of the power instead of by creation date
+    for (const giftType in giftsList) {
+      for (const gift in giftsList[giftType].powers) {
+        giftsList[giftType].powers = giftsList[giftType].powers.sort(function(power1, power2) {
+          // If the levels are the same, sort alphabetically instead
+          if (power1.system.level === power2.system.level) {
+            return power1.name.localeCompare(power2.name)
+          }
+
+          // Sort by level
+          return power1.system.level - power2.system.level
+        })
+      }
+    }
+
+    // Sort the rite containers by the level of the power instead of by creation date
+    ritesList = ritesList.sort(function(power1, power2) {
+      // If the levels are the same, sort alphabetically instead
+      if (power1.system.level === power2.system.level) {
+        return power1.name.localeCompare(power2.name)
+      }
+
+      // Sort by level
+      return power1.system.level - power2.system.level
+    })
 
     actorData.system.giftsList = giftsList
     actorData.system.ritesList = ritesList

--- a/module/main.js
+++ b/module/main.js
@@ -842,7 +842,7 @@ function rerollDie (roll) {
     } else if (charactertype === 'werewolf') { // Werewolf-specific dice
       rollWerewolfDice(diceSelected, speaker, game.i18n.localize('VTM5E.WillpowerReroll'), 0, 0, true)
     } else { // Everything else
-      rollDice(diceSelected, speaker, game.i18n.localize('VTM5E.WillpowerReroll'), 0, false, false, true)
+      rollDice(diceSelected, speaker, game.i18n.localize('VTM5E.WillpowerReroll'), 0, 0, false, true)
     }
   }
 }

--- a/templates/actor/parts/vampire/disciplines.html
+++ b/templates/actor/parts/vampire/disciplines.html
@@ -73,7 +73,7 @@
                             <div class="item-controls">
                                 <!-- Icon to roll the power's rouse check, if applicable -->
                                 {{#if item.system.rouse}}
-                                    <a class="item-control item-rouse" title="{{localize 'VTM5E.RollRouse'}}" data-roll="{{discipline.value}}">
+                                    <a class="item-control item-rouse" title="{{localize 'VTM5E.RollRouse'}}" data-cost="{{discipline.cost}}">
                                         <i class="fas fa-dice-d20"></i>
                                     </a>
                                 {{/if}}

--- a/templates/actor/parts/vampire/rouse.html
+++ b/templates/actor/parts/vampire/rouse.html
@@ -1,7 +1,7 @@
 <div class="resource flex-group-center rouse">
     <label for="placeholder" class="resource-label">{{localize "VTM5E.Rouse"}}</label>
     <div class="resource-content flexrow flex-center flex-between">
-        <button class="rollable" type="button" name="rouse" data-system="{{../actor.system.gamesystem}}" data-roll="1" data-use-hunger="false"
-            data-label="{{localize 'VTM5E.RousingBlood'}}..." data-increase-hunger="true">{{localize "VTM5E.Roll"}}</button>
+        <button class="rouse-check" type="button" name="rouse" data-system="{{../actor.system.gamesystem}}" data-roll="1" data-use-hunger="false"
+            data-label="{{localize 'VTM5E.RousingBlood'}}..." data-increase-hunger="true" data-difficulty="1">{{localize "VTM5E.Roll"}}</button>
     </div>
 </div>    

--- a/templates/item/item-power-sheet.html
+++ b/templates/item/item-power-sheet.html
@@ -4,9 +4,9 @@
         <div class="header-fields flexcol">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}"
                     placeholder="{{localize 'VTM5E.Name'}}" /></h1>
-            <div class="flexrow">
+            <div class="flexrow grid-2row">
                 <!-- Input the level of the discipline -->
-                <div class="flexrow level">
+                <div class="flexcol level flex-center">
                     <label>{{localize "VTM5E.Level"}}</label>
                     <input name="system.level" value="{{item.system.level}}" type="number" min="0" max="5"/>
                 </div>
@@ -33,16 +33,6 @@
 
         {{!-- Description Tab --}}
         <div class="tab" data-group="primary" data-tab="description">
-            <!-- it's a bit clunky trying to break things up. Easier to implement expanding powers with just one description too-->
-            <!-- <label class="resource-label">{{localize "VTM5E.Cost"}}: </label>
-            <div class="half-height">
-            {{editor endirchedCost target="data.cost" button=true editable=editable}}
-            </div>
-            <label class="resource-label">{{localize "VTM5E.Duration"}}: </label>
-            <div class="half-height">
-            {{editor enrichedDuration target="data.duration" button=true editable=editable}}
-            </div> -->
-            <!-- <label class="resource-label">{{localize "VTM5E.System"}}: </label> -->
             {{editor enrichedDescription target="system.description" button=true editable=editable}}
         </div>
 
@@ -103,6 +93,12 @@
                 <!-- If the item has a rouse check to roll or not -->
                 <label class="resource-label">{{localize "VTM5E.Rouse"}}: </label>
                 <input type="checkbox" id="system.rouse" name="system.rouse" {{checked item.system.rouse}}>
+
+                <!-- The cost of the rouse check, only visible when Rouse is true -->
+                {{#if item.system.rouse }}
+                    <label class="resource-label">{{localize "VTM5E.Cost"}}: </label>
+                    <input name="system.cost" value="{{item.system.cost}}" type="number" min="0">
+                {{/if}}
             </div>
         </div>
     </section>


### PR DESCRIPTION
Fixes multiple things:
* Willpower rerolls on vampires are now working again
* Discipline rolls will now roll hunger dice again
* Ghouls will now take aggravated damage on clicking the rouse button if the discipline power is greater than level 1
* Edges, disciplines, rites and gifts will now be sorted by level