### PR TITLE
Various adjustments to the Biography and Blood tabs to make things more intuitive

### DIFF
--- a/css/hunter-sheet.css
+++ b/css/hunter-sheet.css
@@ -17,13 +17,13 @@
 }
 
 /* Styles specific to the Hunter sheets */
-.wod5e.hunter-sheet .item-image.edge-rollable img {
-  box-shadow: inset 0 0 5px 0 red;
-}
-
 .wod5e.hunter-sheet .profile-img,
 .wod5e.hunter-sheet .item-image img {
   background: var(--hunter-primary);
+}
+
+.wod5e.hunter-sheet .item-image.edge-rollable img {
+  box-shadow: inset 0 0 5px 0 red;
 }
 
 .wod5e.hunter-sheet .sheet-banner {

--- a/css/hunter-sheet.css
+++ b/css/hunter-sheet.css
@@ -17,6 +17,10 @@
 }
 
 /* Styles specific to the Hunter sheets */
+.wod5e.hunter-sheet .item-image.edge-rollable img {
+  box-shadow: inset 0 0 5px 0 red;
+}
+
 .wod5e.hunter-sheet .profile-img,
 .wod5e.hunter-sheet .item-image img {
   background: var(--hunter-primary);
@@ -74,8 +78,4 @@
   border: 1px solid #000;
   display: inline-block;
   cursor: pointer;
-}
-
-.item-image.edge-rollable img {
-  box-shadow: inset 0px 0px 5px 0px red;
 }

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -992,12 +992,6 @@ button.dialog-button:hover {
     background: white
 }
 
-input[name="system.blood.resonance"] {
-    font-size: 1.2em;
-    font-family: Vollkorn, serif;
-    font-weight: 700;
-}
-
 .sheet-banner {
     display: flex;
     flex-grow: 0;

--- a/css/vtm5e.css
+++ b/css/vtm5e.css
@@ -107,7 +107,7 @@ button:focus {
 }
 
 .item-image.power-rollable img {
-    box-shadow: inset 0px 0px 5px 0px red;
+    box-shadow: inset 0 0 5px 0 red;
 }
 
 .rollable:hover,

--- a/css/werewolf-sheet.css
+++ b/css/werewolf-sheet.css
@@ -21,6 +21,10 @@
 }
 
 /* Styles specific to the Werewolf sheets */
+.wod5e.werewolf-sheet .item-image.gift-rollable img {
+  box-shadow: inset 0 0 5px 0 red;
+}
+
 .wod5e.werewolf-sheet .profile-img,
 .wod5e.werewolf-sheet .item-image img {
   background: var(--werewolf-primary);
@@ -146,8 +150,4 @@
 
 .wod5e.werewolf-sheet .crinos-health .resource-counter-step {
   border: 1px solid #c11f1f;
-}
-
-.item-image.gift-rollable img {
-  box-shadow: inset 0px 0px 5px 0px red;
 }

--- a/css/werewolf-sheet.css
+++ b/css/werewolf-sheet.css
@@ -21,13 +21,13 @@
 }
 
 /* Styles specific to the Werewolf sheets */
-.wod5e.werewolf-sheet .item-image.gift-rollable img {
-  box-shadow: inset 0 0 5px 0 red;
-}
-
 .wod5e.werewolf-sheet .profile-img,
 .wod5e.werewolf-sheet .item-image img {
   background: var(--werewolf-primary);
+}
+
+.wod5e.werewolf-sheet .item-image.gift-rollable img {
+  box-shadow: inset 0 0 5px 0 red;
 }
 
 .wod5e.werewolf-sheet .sheet-banner {

--- a/module/actor/cell-actor-sheet.js
+++ b/module/actor/cell-actor-sheet.js
@@ -1,4 +1,4 @@
-/* global game, mergeObject, TextEditor */
+/* global game, mergeObject */
 
 import { WoDActor } from './wod-v5-sheet.js'
 
@@ -51,7 +51,7 @@ export class CellActorSheet extends WoDActor {
     data.sheetType = `${game.i18n.localize('WOD5E.Cell')}`
 
     data.dtypes = ['String', 'Number', 'Boolean']
-    
+
     // Prepare items.
     if (this.actor.type === 'cell') {
       this._prepareItems(data)

--- a/module/actor/coterie-actor-sheet.js
+++ b/module/actor/coterie-actor-sheet.js
@@ -1,4 +1,4 @@
-/* global game, mergeObject, TextEditor */
+/* global game, mergeObject */
 
 import { WoDActor } from './wod-v5-sheet.js'
 

--- a/module/actor/mortal-actor-sheet.js
+++ b/module/actor/mortal-actor-sheet.js
@@ -1,4 +1,4 @@
-/* global game, mergeObject, TextEditor */
+/* global game, mergeObject */
 
 // Export this function to be used in other scripts
 import { CoterieActorSheet } from './coterie-actor-sheet.js'

--- a/module/actor/wod-v5-sheet.js
+++ b/module/actor/wod-v5-sheet.js
@@ -1,4 +1,4 @@
-/* global DEFAULT_TOKEN, ChatMessage, duplicate, ActorSheet, game, renderTemplate, Dialog */
+/* global DEFAULT_TOKEN, ChatMessage, duplicate, ActorSheet, game, renderTemplate, Dialog, TextEditor */
 
 import { rollDice } from './roll-dice.js'
 import { rollHunterDice } from './roll-hunter-dice.js'

--- a/module/actor/wod-v5-sheet.js
+++ b/module/actor/wod-v5-sheet.js
@@ -25,7 +25,7 @@ export class WoDActor extends ActorSheet {
     if (actorData.equipment) { data.enrichedEquipment = await TextEditor.enrichHTML(actorData.equipment, { async: true }) }
 
     // Enrich actor header editor fields
-    if(actorHeaders) {
+    if (actorHeaders) {
       if (actorHeaders.tenets) { data.enrichedTenets = await TextEditor.enrichHTML(actorHeaders.tenets, { async: true }) }
       if (actorHeaders.touchstones) { data.enrichedTouchstones = await TextEditor.enrichHTML(actorHeaders.touchstones, { async: true }) }
 

--- a/templates/actor/parts/biography.html
+++ b/templates/actor/parts/biography.html
@@ -1,73 +1,40 @@
 <div class="tab" data-group="primary" data-tab="description">
     {{#if isCharacter}}
-    {{#if actor.system.clan.value}}
-    <div class="resource flexrow grid grid-3col">
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Concept"}}</label>
-            <input type="text" name="system.headers.concept" value="{{actor.system.headers.concept}}" />
-        </div>
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Chronicle"}}</label>
-            <input type="text" name="system.headers.chronicle" value="{{actor.system.headers.chronicle}}" />
-        </div>
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Ambition"}}</label>
-            <input type="text" name="system.headers.ambition" value="{{actor.system.headers.ambition}}" />
-        </div>
-    </div>
-    {{else}}
     <div class="resource flexrow grid grid-4col">
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Concept"}}</label>
-            <input type="text" name="system.headers.concept" value="{{actor.system.headers.concept}}" />
+            <input type="text" name="system.headers.concept" value="{{actor.system.headers.concept}}" placeholder="{{localize 'WOD5E.Concept'}}" />
         </div>
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Chronicle"}}</label>
-            <input type="text" name="system.headers.chronicle" value="{{actor.system.headers.chronicle}}" />
+            <input type="text" name="system.headers.chronicle" value="{{actor.system.headers.chronicle}}" placeholder="{{localize 'WOD5E.Chronicle'}}" />
         </div>
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Ambition"}}</label>
-            <input type="text" name="system.headers.ambition" value="{{actor.system.headers.ambition}}" />
+            <input type="text" name="system.headers.ambition" value="{{actor.system.headers.ambition}}" placeholder="{{localize 'WOD5E.Ambition'}}" />
         </div>
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Desire"}}</label>
-            <input type="text" name="system.headers.desire" value="{{actor.system.headers.desire}}" />
+            <input type="text" name="system.headers.desire" value="{{actor.system.headers.desire}}" placeholder="{{localize 'WOD5E.Desire'}}" />
         </div>
     </div>
-    {{/if}}
     <div class="resource flexrow grid grid-3col">
-        {{#if actor.system.clan.value}}
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Sire"}}</label>
-            <input type="text" name="system.headers.sire" value="{{actor.system.headers.sire}}" />
-        </div>
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Generation"}}</label>
-            <input type="text" name="system.headers.generation" value="{{actor.system.headers.generation}}" />
-        </div>
-        {{/if}}
-        {{#if actor.system.headers.cellname}}
+        {{#ifeq actor.system.gamesystem 'hunter'}}
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Creed"}}</label>
-            <input type="text" name="system.creed.value" value="{{actor.system.creed.value}}" />
+            <input type="text" name="system.creed.value" value="{{actor.system.creed.value}}" placeholder="{{localize 'WOD5E.Creed'}}" />
         </div>
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Drive"}}</label>
-            <input type="text" name="system.drive.value" value="{{actor.system.drive.value}}" />
+            <input type="text" name="system.drive.value" value="{{actor.system.drive.value}}" placeholder="{{localize 'WOD5E.Drive'}}" />
         </div>
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.Redemption"}}</label>
-            <input type="text" name="system.redemption.value" value="{{actor.system.redemption.value}}" />
+            <input type="text" name="system.redemption.value" value="{{actor.system.redemption.value}}" placeholder="{{localize 'WOD5E.Redemption'}}" />
         </div>
-        {{/if}}
-        {{#if actor.system.clan.value}}
-        <div class="flex-group-center">
-            <label class="resource-label">{{localize "WOD5E.Desire"}}</label>
-            <input type="text" name="system.headers.desire" value="{{actor.system.headers.desire}}" />
-        </div>
-        {{/if}}
+        {{/ifeq}}
     </div>
-    {{#if (or actor.system.clan.value actor.system.headers.cellname)}} 
+    {{#ifeq actor.system.gamesystem 'hunter'}}
     <div class="resource flexrow grid grid-3col" style="min-height: 264px;">
         <div class="flex-group-left">
             <div class="flex-center">
@@ -85,17 +52,7 @@
                 {{editor enrichedTouchstones target="system.headers.touchstones" button=true editable=editable}}
             </div>
         </div>
-        {{#if actor.system.clan.value}}
-        <div class="flex-group-left">
-            <div class="flex-center">
-                <label class="resource-label">{{localize "WOD5E.ClanBane"}}</label>
-            </div>
-            <div class="description-content">
-                {{editor enrichedBane target="system.headers.bane" button=true editable=editable}}
-            </div>
-        </div>
-        {{/if}}
-        {{#if actor.system.headers.cellname}}
+        {{#ifeq actor.system.gamesystem 'hunter'}}
         <div class="flex-group-left">
             <div class="flex-center">
                 <label class="resource-label">{{localize "WOD5E.CreedFields"}}</label>
@@ -104,7 +61,7 @@
                 {{editor enrichedCreedFields target="system.headers.creedfields" button=true editable=editable}}
             </div>
         </div>
-        {{/if}}
+        {{/ifeq}}
     </div>
     {{else}}
     <div class="resource flexrow grid grid-2col" style="min-height: 264px;">
@@ -125,7 +82,7 @@
             </div>
         </div>
     </div>
-    {{/if}}
+    {{/ifeq}}
     {{/if}}
     {{#if isCharacter}}
     <div class="resource flexrow grid grid-2col" style="min-height: 264px;"> 

--- a/templates/actor/parts/vampire/blood.html
+++ b/templates/actor/parts/vampire/blood.html
@@ -1,4 +1,18 @@
 <div class="tab blood" data-group="primary" data-tab="blood">
+    <div class="resource flexrow grid grid-3col">
+        <div class="flex-group-center">
+            <label class="resource-label">{{localize "WOD5E.Sire"}}</label>
+            <input type="text" name="system.headers.sire" value="{{actor.system.headers.sire}}" placeholder="{{localize 'WOD5E.Sire'}}" />
+        </div>
+        <div class="flex-group-center">
+            <label class="resource-label">{{localize "WOD5E.Generation"}}</label>
+            <input type="text" name="system.headers.generation" value="{{actor.system.headers.generation}}" placeholder="{{localize 'WOD5E.Generation'}}" />
+        </div>
+        <div class="flex-group-center">
+            <label class="resource-label">{{localize "WOD5E.BloodResonance"}}</label>
+            <input type="text" name="system.blood.resonance" value="{{actor.system.blood.resonance}}" placeholder="{{localize 'WOD5E.BloodResonance'}}" />
+        </div>
+    </div>
     <div class="resource flexrow grid grid-2col">
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.BloodPotency"}}: </label>
@@ -9,10 +23,7 @@
                 {{/numLoop}}
             </div>
         </div>
-        <div class="flex-group-center flexrow">
-            <label class="resource-label">{{localize "WOD5E.BloodResonance"}}: </label>
-            <input type="text" name="system.blood.resonance" value="{{actor.system.blood.resonance}}" />
-        </div>
+        {{> "systems/vtm5e/templates/actor/parts/vampire/humanity.html"}}
     </div>
     <div class="resource flexrow grid grid-2col">
         <div class="flex-group-center">
@@ -38,6 +49,14 @@
         <div class="flex-group-center">
             <label class="resource-label">{{localize "WOD5E.BaneSeverity"}}:</label>
             <p>{{lookup blood_potency_text "bane"}}</p>
+        </div>
+        <div class="flex-group-center">
+            <div class="flex-center">
+                <label class="resource-label">{{localize "WOD5E.ClanBane"}}</label>
+            </div>
+            <div class="description-content">
+                {{editor enrichedBane target="system.headers.bane" button=true editable=editable}}
+            </div>
         </div>
     </div>
 </div>

--- a/templates/actor/vampire-sheet.html
+++ b/templates/actor/vampire-sheet.html
@@ -34,8 +34,6 @@
                   {{> "systems/vtm5e/templates/actor/parts/exp.html"}}
   
                   {{!-- Anything more that needs to be in the header spot --}}
-                  {{> "systems/vtm5e/templates/actor/parts/vampire/humanity.html"}}
-
                   {{> "systems/vtm5e/templates/actor/parts/vampire/hunger.html"}}
   
                   {{> "systems/vtm5e/templates/actor/parts/vampire/rouse.html"}}


### PR DESCRIPTION
Namely, I've done the following:
* Moved Humanity to the Blood tab (to stay in line with the Hauglosk and Harano trackers on the Werewolf sheet, and to make more room for if a character has more HP in the header fields)
* Moved "Sire" "Generation" and "Blood Resonance" as well as "Clan Bane" to the Blood tab as well.
* Sire, generation, and Blood Resonance will now appear even if the Clan field isn't filled in.
* Creed, Drive, and Redemption will now appear even if the Cell field isn't filled in.